### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After installation, run:
 1. `bin/magento setup:upgrade`
 2. `bin/magento setup:di:compile`
 3. `bin/magento setup:static-content:deploy [locale-codes, e.g. nl_NL en_US]`
-4. `bin/magento cache:fluche`
+4. `bin/magento cache:flush`
 
 Done!
 


### PR DESCRIPTION
This PR fixes a typo in the readme

`bin/magento cache:fluche` should be written as `bin/magento cache:flush`