### PR TITLE
XSS prevention: escaping in phtml. Use $block instead $this.

### DIFF
--- a/view/adminhtml/templates/config/form/validate.phtml
+++ b/view/adminhtml/templates/config/form/validate.phtml
@@ -31,10 +31,10 @@
  */
 ?>
 
-<span id="message_span" data-mage-init='{"glsValidate": {"url": "<?php echo $this->getValidateUrl(); ?>"}}'>
+<span id="message_span" data-mage-init='{"glsValidate": {"url": "<?php echo $block->escapeUrl($block->getValidateUrl()); ?>"}}'>
     <div class="loader"></div>
-    <span class="validation-message unknown"><?php echo __('Validating API credentials'); ?></span>
-    <span class="validation-message error" style="display: none;"><?php echo __('API credentials are incorrect'); ?></span>
-    <span class="validation-message unable-to-retrieve" style="display: none;"><?php echo __('Unable to validate API credentials'); ?></span>
-    <span class="validation-message success" style="display: none;"><?php echo __('API credentials are correct'); ?></span>
+    <span class="validation-message unknown"><?php echo $block->escapeHtml(__('Validating API credentials')); ?></span>
+    <span class="validation-message error" style="display: none;"><?php echo $block->escapeHtml(__('API credentials are incorrect')); ?></span>
+    <span class="validation-message unable-to-retrieve" style="display: none;"><?php echo $block->escapeHtml(__('Unable to validate API credentials')); ?></span>
+    <span class="validation-message success" style="display: none;"><?php echo $block->escapeHtml(__('API credentials are correct')); ?></span>
 </span>

--- a/view/adminhtml/templates/config/support/tab.phtml
+++ b/view/adminhtml/templates/config/support/tab.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var \TIG\GLS\Block\Adminhtml\Config\Support\Tab $this */
+/** @var \TIG\GLS\Block\Adminhtml\Config\Support\Tab $block */
 ?>
 <div id="supporttab" class="tig-gls-supporttab" data-mage-init='{"glsConfig": true}'>
 
@@ -13,32 +13,32 @@
                     <span class="text">
                         <?php echo $block->escapeHtml(__('Supported Magento versions'));?>:
                     </span>
-                        <span class="version"><?php echo $block->escapeHtml($this->getSupportedMagentoVersions()); ?></span>
+                        <span class="version"><?php echo $block->escapeHtml($block->getSupportedMagentoVersions()); ?></span>
                     </li>
                     <li>
                         <span class="text"><?php echo $block->escapeHtml(__('Extension version'));?>:</span>
-                        <span class="version"><?php echo $block->escapeHtml($this->getVersionNumber()); ?></span>
+                        <span class="version"><?php echo $block->escapeHtml($block->getVersionNumber()); ?></span>
                     </li>
                     <span class="text"><?php echo $block->escapeHtml(__('Your PHP version'));?>:</span>
                     <span class="version">
-                            <a href="http://devdocs.magento.com/guides/v<?php echo $this->getMagentoVersionTidyString() ;?>/install-gde/system-requirements-tech.html"
+                            <a href="http://devdocs.magento.com/guides/v<?php echo $block->getMagentoVersionTidyString() ;?>/install-gde/system-requirements-tech.html"
                                target="_blank">
-                                <?php echo $block->escapeHtml(implode('.', $this->getPhpVersionArray())); ?>
+                                <?php echo $block->escapeHtml(implode('.', $block->getPhpVersionArray())); ?>
                                 </a>
                                 &nbsp;
-                        <?php switch ($this->phpVersionCheck()) {
+                        <?php switch ($block->phpVersionCheck()) {
                             case 1:
-                                echo '<img class="compatible-image" height="16" src="' . $this->getViewFileUrl(
+                                echo '<img class="compatible-image" height="16" src="' . $block->getViewFileUrl(
                                         'TIG_GLS::images/green-ok.png'
                                     ) . '" alt="">';
                                 break;
                             case 0:
-                                echo '<img class="compatible-image" height="16" src="' . $this->getViewFileUrl(
+                                echo '<img class="compatible-image" height="16" src="' . $block->getViewFileUrl(
                                         'TIG_GLS::images/red-nok.png'
                                     ) . '" alt="">';
                                 break;
                             default:
-                                echo '<img class="compatible-image" height="16" src="' . $this->getViewFileUrl(
+                                echo '<img class="compatible-image" height="16" src="' . $block->getViewFileUrl(
                                         'TIG_GLS::images/orange-unknown.png'
                                     ) . '" alt="">';
                                 break;
@@ -53,15 +53,18 @@
 
     <div id="section">
         <div class="collapse-title" data-role="title">
-            <h3 data-role="trigger"><?php echo $block->escapeHtml(__('Support'));?></h3>
+            <h3 data-role="trigger"><?php echo $block->escapeHtml(__('Support')); ?></h3>
         </div>
         <div class="collapse-content support-gls-tig" data-role="content" style="display:none;">
-            <?php echo __('This extension is developed by <a href="https://tig.nl" target="_BLANK">TIG</a>');?>
+            <?php echo $block->escapeHtml(
+                __('This extension is developed by <a href="https://tig.nl" target="_BLANK">TIG</a>'),
+               ['a']
+            ); ?>
 
             <div class="colset-2">
                 <div class="col-1">
-                    <h4><?php echo __('Extension basic configuration and account information');?></h4>
-                    <?php echo __('Please contact:'); ?> <a href="mailto:helpdesk@gls-netherlands.com">helpdesk@gls-netherlands.com</a>
+                    <h4><?php echo $block->escapeHtml(__('Extension basic configuration and account information')); ?></h4>
+                    <?php echo $block->escapeHtml(__('Please contact:')); ?> <a href="mailto:helpdesk@gls-netherlands.com">helpdesk@gls-netherlands.com</a>
                 </div>
                 <div class="col-2">
 


### PR DESCRIPTION
Hi!

PR contains fixes for consistency and supports Magento Guide Lines:
1. Escaping for translations
2. Using $block instead $this in templates

Please review,   
